### PR TITLE
Unsubscribe from websocket when initial connection fails

### DIFF
--- a/app/components/ChatContainer.js
+++ b/app/components/ChatContainer.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {Component} from 'react';
 import {FormattedMessage} from 'react-intl';
-import {addMessage, subscribe, fetchConversation} from 'quiq-chat';
+import {addMessage, subscribe, fetchConversation, unsubscribe} from 'quiq-chat';
 import {formatMessage} from 'utils/i18n';
 import Spinner from 'Spinner';
 import MessageForm from 'MessageForm';
@@ -70,6 +70,7 @@ export class ChatContainer extends Component {
       const conversation = await fetchConversation();
       this.setState({messages: this.getTextMessages(conversation.messages)});
     } catch (err) {
+      unsubscribe();
       this.handleApiError(err, this.initialize);
     }
   };

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.15.0",
     "qs": "6.4.0",
-    "quiq-chat": "1.0.1",
+    "quiq-chat": "1.1.0",
     "react": "15.6.0",
     "react-dom": "15.6.0",
     "react-intl": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5763,9 +5763,9 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
-quiq-chat@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/quiq-chat/-/quiq-chat-1.0.1.tgz#84fafdde5400b869a247deaae6884289beab716d"
+quiq-chat@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quiq-chat/-/quiq-chat-1.1.0.tgz#4a4ac81dba9e32f5bc7467122232d1b6a645ec1e"
   dependencies:
     atmosphere.js "https://github.com/Quiq/atmosphere-js/tarball/cf35c913143cf2c391b6bcb694ae8a47794a1b88"
     isomorphic-fetch "2.2.1"


### PR DESCRIPTION
We were creating multiple websocket connections when the promise was rejected.  This clears any existing connections before we attempt connecting again.