### PR TITLE
Agents available fix

### DIFF
--- a/app/Routes.js
+++ b/app/Routes.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Launcher from 'Launcher';
-import ChatContainer from 'ChatContainer';
 import CompatibilityWrapper from 'CompatibilityWrapper';
 import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
 
@@ -8,7 +7,7 @@ const routes = () =>
   <Router>
     <CompatibilityWrapper>
       <Switch>
-        <Route exact path="/app/webchat/standalone" component={ChatContainer} />
+        <Route exact path="/app/webchat/standalone" component={Launcher} />
         <Route component={Launcher} />
       </Switch>
     </CompatibilityWrapper>

--- a/app/__mocks__/ChatClient.js
+++ b/app/__mocks__/ChatClient.js
@@ -15,7 +15,7 @@ export const getChatClient = jest.fn().mockReturnValue({
   updateMessagePreview: jest.fn(),
   sendRegistration: jest.fn(),
   checkForAgents: jest.fn(),
-  hasActiveChat: jest.fn(),
+  hasTakenMeaningfulAction: jest.fn(),
   getLastUserEvent: jest.fn(),
   isRegistered: jest.fn().mockReturnValue(false),
   isChatVisible: jest.fn(),

--- a/app/actions/__tests__/__snapshots__/chatActions.test.js.snap
+++ b/app/actions/__tests__/__snapshots__/chatActions.test.js.snap
@@ -7,10 +7,10 @@ Object {
 }
 `;
 
-exports[`chatActions setChatHidden builds an action 1`] = `
+exports[`chatActions setChatContainerHidden builds an action 1`] = `
 Object {
-  "hidden": true,
-  "type": "CHAT_HIDDEN",
+  "chatContainerHidden": true,
+  "type": "CHAT_CONTAINER_HIDDEN",
 }
 `;
 
@@ -18,6 +18,13 @@ exports[`chatActions setChatInitialized builds an action 1`] = `
 Object {
   "initializedState": "initialized",
   "type": "CHAT_INITIALIZED_STATE",
+}
+`;
+
+exports[`chatActions setChatLauncherHidden builds an action 1`] = `
+Object {
+  "chatLauncherHidden": true,
+  "type": "CHAT_LAUNCHER_HIDDEN",
 }
 `;
 

--- a/app/actions/__tests__/chatActions.test.js
+++ b/app/actions/__tests__/chatActions.test.js
@@ -3,9 +3,15 @@ import * as chatActions from '../chatActions';
 import {getMockMessage} from 'utils/testHelpers';
 
 describe('chatActions', () => {
-  describe('setChatHidden', () => {
+  describe('setChatContainerHidden', () => {
     it('builds an action', () => {
-      expect(chatActions.setChatHidden(true)).toMatchSnapshot();
+      expect(chatActions.setChatContainerHidden(true)).toMatchSnapshot();
+    });
+  });
+
+  describe('setChatLauncherHidden', () => {
+    it('builds an action', () => {
+      expect(chatActions.setChatLauncherHidden(true)).toMatchSnapshot();
     });
   });
 

--- a/app/actions/chatActions.js
+++ b/app/actions/chatActions.js
@@ -1,8 +1,13 @@
 import type {ChatInitializedStateType, Message} from 'types';
 
-export const setChatHidden = (hidden: boolean) => ({
-  type: 'CHAT_HIDDEN',
-  hidden,
+export const setChatContainerHidden = (chatContainerHidden: boolean) => ({
+  type: 'CHAT_CONTAINER_HIDDEN',
+  chatContainerHidden,
+});
+
+export const setChatLauncherHidden = (chatLauncherHidden: boolean) => ({
+  type: 'CHAT_LAUNCHER_HIDDEN',
+  chatLauncherHidden,
 });
 
 export const setChatInitialized = (initializedState: ChatInitializedStateType) => ({

--- a/app/components/ChatContainer.js
+++ b/app/components/ChatContainer.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import {getChatClient} from '../ChatClient';
 import QUIQ, {validateWelcomeFormDefinition} from 'utils/quiq';
 import {inStandaloneMode} from 'utils/utils';
 import classnames from 'classnames';
@@ -9,104 +8,26 @@ import WelcomeForm from 'WelcomeForm';
 import MessageForm from 'MessageForm';
 import HeaderMenu from 'HeaderMenu';
 import Transcript from 'Transcript';
+import {getChatClient} from '../ChatClient';
 import Spinner from 'Spinner';
 import {formatMessage} from 'utils/i18n';
 import {connect} from 'react-redux';
-import * as chatActions from 'actions/chatActions';
 import {ChatInitializedState} from 'appConstants';
 import './styles/ChatContainer.scss';
-import type {ChatState, ChatInitializedStateType, Message} from 'types';
-import type {QuiqChatClientType} from 'quiq-chat';
+import type {ChatState, ChatInitializedStateType} from 'types';
 
 export type ChatContainerProps = {
-  hidden: boolean,
-  transcript: Array<Message>,
+  chatContainerHidden: boolean,
   welcomeFormSubmitted: boolean,
   initializedState: ChatInitializedStateType,
-  setChatHidden: (hidden: boolean) => void,
-  setChatInitialized: (initialized: ChatInitializedStateType) => void,
-  setWelcomeFormSubmitted: (welcomeFormSubmitted: boolean) => void,
-  setAgentTyping: (typing: boolean) => void,
-  updateTranscript: (transcript: Array<Message>) => void,
 };
 
 export class ChatContainer extends React.Component {
   props: ChatContainerProps;
-  client: QuiqChatClientType;
-  typingTimeout: ?number;
-
-  constructor() {
-    super();
-    this.client = getChatClient();
-  }
 
   componentDidMount() {
     if (!this.props.welcomeFormSubmitted) validateWelcomeFormDefinition();
-
-    this.client
-      .onNewMessages(this.props.updateTranscript)
-      .onAgentTyping(this.handleAgentTyping)
-      .onConnectionStatusChange((connected: boolean) =>
-        this.props.setChatInitialized(
-          connected ? ChatInitializedState.INITIALIZED : ChatInitializedState.DISCONNECTED,
-        ),
-      )
-      .onError(() => this.props.setChatInitialized(ChatInitializedState.ERROR))
-      .onErrorResolved(() => this.props.setChatInitialized(ChatInitializedState.INITIALIZED))
-      .onBurn(() => this.props.setChatInitialized(ChatInitializedState.ERROR));
-
-    if (inStandaloneMode()) {
-      this.props.setChatHidden(false);
-      this.init();
-    } else if (
-      this.props.initializedState === ChatInitializedState.UNINITIALIZED &&
-      !this.props.hidden
-    ) {
-      this.init();
-    }
   }
-
-  componentWillReceiveProps(nextProps: ChatContainerProps) {
-    if (
-      this.props.initializedState === ChatInitializedState.UNINITIALIZED &&
-      this.props.hidden &&
-      !nextProps.hidden
-    ) {
-      this.init();
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.typingTimeout) clearTimeout(this.typingTimeout);
-  }
-
-  init = async () => {
-    if (this.props.initializedState === ChatInitializedState.LOADING) return;
-
-    try {
-      this.props.setChatInitialized(ChatInitializedState.LOADING);
-      await this.client.start();
-      this.props.setChatInitialized(ChatInitializedState.INITIALIZED);
-      if (this.props.transcript.length > 0) {
-        this.props.setWelcomeFormSubmitted(true);
-      }
-    } catch (e) {
-      this.props.setChatInitialized(ChatInitializedState.ERROR);
-    }
-  };
-
-  handleAgentTyping = (typing: boolean) => {
-    this.props.setAgentTyping(typing);
-
-    if (this.typingTimeout) {
-      clearTimeout(this.typingTimeout);
-    }
-    if (!typing) return;
-
-    this.typingTimeout = setTimeout(() => {
-      this.props.setAgentTyping(false);
-    }, 10000);
-  };
 
   renderBanner = () => {
     switch (this.props.initializedState) {
@@ -164,16 +85,17 @@ export class ChatContainer extends React.Component {
   };
 
   render() {
+    if (this.props.chatContainerHidden) return null;
+
     const classNames = classnames(`ChatContainer ${this.props.initializedState}`, {
       standaloneMode: inStandaloneMode(),
       hasCustomLauncher: !inStandaloneMode() && QUIQ.CUSTOM_LAUNCH_BUTTONS.length > 0,
-      hidden: this.props.hidden,
     });
 
     if (
       this.props.initializedState === ChatInitializedState.INITIALIZED &&
       !this.props.welcomeFormSubmitted &&
-      !this.client.isRegistered()
+      !getChatClient().isRegistered()
     ) {
       return (
         <div className={classNames} style={{width: QUIQ.WIDTH, maxHeight: QUIQ.HEIGHT}}>
@@ -192,12 +114,8 @@ export class ChatContainer extends React.Component {
   }
 }
 
-export default connect(
-  (state: ChatState) => ({
-    hidden: state.hidden,
-    initializedState: state.initializedState,
-    welcomeFormSubmitted: state.welcomeFormSubmitted,
-    transcript: state.transcript,
-  }),
-  chatActions,
-)(ChatContainer);
+export default connect((state: ChatState) => ({
+  chatContainerHidden: state.chatContainerHidden,
+  initializedState: state.initializedState,
+  welcomeFormSubmitted: state.welcomeFormSubmitted,
+}))(ChatContainer);

--- a/app/components/HeaderMenu.js
+++ b/app/components/HeaderMenu.js
@@ -4,19 +4,19 @@ import {inStandaloneMode, isIEorSafari} from 'utils/utils';
 import {formatMessage} from 'utils/i18n';
 import QUIQ, {openStandaloneMode} from 'utils/quiq';
 import messages from 'messages';
-import {setChatHidden, setChatPopped} from 'actions/chatActions';
+import {setChatContainerHidden, setChatPopped} from 'actions/chatActions';
 import {connect} from 'react-redux';
 import {getChatClient} from '../ChatClient';
 import './styles/HeaderMenu.scss';
 
 export type HeaderMenuProps = {
-  setChatHidden: (hidden: boolean) => void, // eslint-disable-line react/no-unused-prop-types
+  setChatContainerHidden: (chatContainerHidden: boolean) => void, // eslint-disable-line react/no-unused-prop-types
   setChatPopped: (popped: boolean) => void, // eslint-disable-line react/no-unused-prop-types
 };
 
 export const HeaderMenu = (props: HeaderMenuProps) => {
   const minimize = () => {
-    props.setChatHidden(true);
+    props.setChatContainerHidden(true);
     getChatClient().leaveChat();
   };
 
@@ -67,4 +67,4 @@ export const HeaderMenu = (props: HeaderMenuProps) => {
   );
 };
 
-export default connect(null, {setChatHidden, setChatPopped})(HeaderMenu);
+export default connect(null, {setChatContainerHidden, setChatPopped})(HeaderMenu);

--- a/app/components/Launcher.js
+++ b/app/components/Launcher.js
@@ -124,7 +124,7 @@ export class Launcher extends Component {
   };
 
   init = async () => {
-    this.determineLauncherState();
+    await this.determineLauncherState();
 
     // Standalone Mode
     // Never show launcher
@@ -136,16 +136,12 @@ export class Launcher extends Component {
       return;
     }
 
-    // ChatContainer Visible
-    // Show launcher if transcript length > 0
-    // Always start session, show ChatContainer if launcher visible
+    // ChatContainer Visible from cookie
+    // Always start session, always show launcher
     if (this.client.isChatVisible()) {
       await this.startSession();
-
-      if (!this.props.chatLauncherHidden) {
-        this.updateContainerHidden(false);
-      }
-
+      this.updateLauncherHidden(false);
+      this.updateContainerHidden(false);
       return;
     }
 
@@ -153,7 +149,7 @@ export class Launcher extends Component {
     // Show launcher if transcript length > 0
     // Always start session, don't change ChatContainer
     if (this.client.hasTakenMeaningfulAction()) {
-      this.startSession();
+      await this.startSession();
     }
 
     if (!this.props.chatLauncherHidden) {

--- a/app/components/Launcher.js
+++ b/app/components/Launcher.js
@@ -6,14 +6,14 @@ import QUIQ, {openStandaloneMode} from 'utils/quiq';
 import ChatContainer from './ChatContainer';
 import ToggleChatButton from './ToggleChatButton';
 import './styles/Launcher.scss';
-import {setChatHidden, setChatPopped} from 'actions/chatActions';
+import * as chatActions from 'actions/chatActions';
 import {getChatClient} from '../ChatClient';
 import messages from 'messages';
-import {displayError, isIEorSafari} from 'utils/utils';
-import {noAgentsAvailableClass} from 'appConstants';
+import {displayError, isIEorSafari, inStandaloneMode} from 'utils/utils';
+import {noAgentsAvailableClass, ChatInitializedState} from 'appConstants';
 import {connect} from 'react-redux';
 import {compose} from 'redux';
-import type {IntlObject, ChatState} from 'types';
+import type {IntlObject, ChatState, Message, ChatInitializedStateType} from 'types';
 import type {QuiqChatClientType} from 'quiq-chat';
 
 type LauncherState = {
@@ -22,65 +22,190 @@ type LauncherState = {
 
 export type LauncherProps = {
   intl: IntlObject,
-  setChatHidden: (hidden: boolean) => void,
-  setChatPopped: (popped: boolean) => void,
-  hidden: boolean,
+  chatContainerHidden: boolean,
+  chatLauncherHidden: boolean,
+  initializedState: ChatInitializedStateType,
+  transcript: Array<Message>,
   popped: boolean,
+
+  setChatPopped: (popped: boolean) => void,
+  setChatContainerHidden: (chatContainerHidden: boolean) => void,
+  setChatLauncherHidden: (chatLauncherHidden: boolean) => void,
+  setChatInitialized: (initialized: ChatInitializedStateType) => void,
+  setWelcomeFormSubmitted: (welcomeFormSubmitted: boolean) => void,
+  setAgentTyping: (typing: boolean) => void,
+  updateTranscript: (transcript: Array<Message>) => void,
 };
 
 export class Launcher extends Component {
   props: LauncherProps;
   state: LauncherState = {};
-  checkForAgentsInterval: number;
+  determineLauncherStateInterval: number;
+  typingTimeout: ?number;
+  autoPopTimeout: ?number;
   client: QuiqChatClientType;
+
+  constructor() {
+    super();
+    this.client = getChatClient();
+  }
 
   componentDidMount() {
     registerIntlObject(this.props.intl);
-    this.client = getChatClient();
+    this.registerClientCallbacks();
     this.bindChatButtons();
+    this.determineLauncherStateInterval = setInterval(this.determineLauncherState, 1000 * 60);
 
-    this.checkForAgentsInterval = setInterval(this.checkForAgents, 1000 * 60);
-    // Check the first time
-    this.checkForAgents();
-
-    this.handleAutoPop();
+    this.init();
   }
 
   componentWillUnmount() {
-    clearInterval(this.checkForAgentsInterval);
+    clearInterval(this.determineLauncherStateInterval);
+    clearTimeout(this.typingTimeout);
+    clearTimeout(this.autoPopTimeout);
   }
+
+  componentWillReceiveProps(nextProps: LauncherProps) {
+    if (
+      QUIQ.CUSTOM_LAUNCH_BUTTONS.length > 0 &&
+      this.props.chatLauncherHidden !== nextProps.chatLauncherHidden
+    ) {
+      this.updateCustomChatButtons(!!nextProps.chatLauncherHidden);
+    }
+  }
+
+  determineLauncherState = async () => {
+    if (
+      // User is in active session, allow them to continue
+      this.client.isChatVisible() ||
+      !this.props.chatContainerHidden ||
+      this.props.popped
+    ) {
+      if (this.props.chatLauncherHidden) {
+        this.props.setChatLauncherHidden(false);
+      }
+      return;
+    }
+
+    const {available} = await this.client.checkForAgents();
+    this.updateLauncherHidden(!available);
+  };
+
+  updateLauncherHidden = (hidden: boolean) => {
+    if (hidden !== this.props.chatLauncherHidden) {
+      this.props.setChatLauncherHidden(hidden);
+    }
+  };
+
+  updateContainerHidden = (hidden: boolean) => {
+    if (hidden !== this.props.chatContainerHidden) {
+      this.props.setChatContainerHidden(hidden);
+    }
+  };
+
+  updateInitializedState = (newState: ChatInitializedStateType) => {
+    if (newState !== this.props.initializedState) {
+      this.props.setChatInitialized(newState);
+    }
+  };
+
+  registerClientCallbacks = () => {
+    this.client
+      .onNewMessages(this.props.updateTranscript)
+      .onAgentTyping(this.handleAgentTyping)
+      .onConnectionStatusChange((connected: boolean) =>
+        this.updateInitializedState(
+          connected ? ChatInitializedState.INITIALIZED : ChatInitializedState.DISCONNECTED,
+        ),
+      )
+      .onError(() => this.updateInitializedState(ChatInitializedState.ERROR))
+      .onErrorResolved(() => this.updateInitializedState(ChatInitializedState.INITIALIZED))
+      .onBurn(() => this.updateInitializedState(ChatInitializedState.ERROR));
+  };
+
+  init = async () => {
+    this.determineLauncherState();
+
+    // Standalone Mode
+    // Never show launcher
+    // Always start session, show ChatContainer
+    if (inStandaloneMode()) {
+      this.updateLauncherHidden(true);
+      this.updateContainerHidden(false);
+      this.startSession();
+      return;
+    }
+
+    // ChatContainer Visible
+    // Show launcher if transcript length > 0
+    // Always start session, show ChatContainer if launcher visible
+    if (this.client.isChatVisible()) {
+      await this.startSession();
+
+      if (!this.props.chatLauncherHidden) {
+        this.updateContainerHidden(false);
+      }
+
+      return;
+    }
+
+    // User has submitted welcome form or sent message, ChatContainer not visible
+    // Show launcher if transcript length > 0
+    // Always start session, don't change ChatContainer
+    if (this.client.hasTakenMeaningfulAction()) {
+      this.startSession();
+    }
+
+    if (!this.props.chatLauncherHidden) {
+      this.handleAutoPop();
+    }
+  };
+
+  startSession = async () => {
+    if (
+      this.props.initializedState === ChatInitializedState.LOADING ||
+      this.props.initializedState === ChatInitializedState.INITIALIZED
+    )
+      return;
+
+    try {
+      this.updateInitializedState(ChatInitializedState.LOADING);
+      await this.client.start();
+      this.updateInitializedState(ChatInitializedState.INITIALIZED);
+
+      // User has session in progress. Send them right to it.
+      if (this.props.transcript.length > 0) {
+        this.updateLauncherHidden(false);
+        this.props.setWelcomeFormSubmitted(true);
+      }
+    } catch (e) {
+      this.updateInitializedState(ChatInitializedState.ERROR);
+    }
+  };
+
+  handleAgentTyping = (typing: boolean) => {
+    this.props.setAgentTyping(typing);
+
+    if (this.typingTimeout) {
+      clearTimeout(this.typingTimeout);
+    }
+    if (!typing) return;
+
+    this.typingTimeout = setTimeout(() => {
+      this.props.setAgentTyping(false);
+    }, 10000);
+  };
 
   handleAutoPop = () => {
     if (!isIEorSafari() && typeof QUIQ.AUTO_POP_TIME === 'number') {
-      setTimeout(() => {
-        this.props.setChatHidden(false);
+      this.autoPopTimeout = setTimeout(() => {
+        if (this.props.chatLauncherHidden) return;
+
+        this.startSession();
+        this.updateContainerHidden(false);
       }, QUIQ.AUTO_POP_TIME);
     }
   };
-
-  checkForAgents = async () => {
-    const chatClient = getChatClient();
-
-    const {available} = await chatClient.checkForAgents();
-    const activeChat = await chatClient.hasActiveChat();
-
-    this.setState({
-      agentsAvailable: activeChat || available,
-    });
-
-    if (chatClient.isChatVisible()) {
-      this.props.setChatHidden(false);
-    }
-  };
-
-  componentWillUpdate(nextProps: LauncherProps, nextState: LauncherState) {
-    if (
-      QUIQ.CUSTOM_LAUNCH_BUTTONS.length > 0 &&
-      this.state.agentsAvailable !== nextState.agentsAvailable
-    ) {
-      this.updateCustomChatButtons(!!nextState.agentsAvailable);
-    }
-  }
 
   updateCustomChatButtons = (agentsAvailable: boolean) => {
     try {
@@ -110,9 +235,7 @@ export class Launcher extends Component {
     }
   };
 
-  toggleChat = () => {
-    const client = getChatClient();
-
+  toggleChat = async () => {
     if (this.props.popped || isIEorSafari()) {
       return openStandaloneMode({
         onPop: () => {
@@ -128,23 +251,23 @@ export class Launcher extends Component {
       });
     }
 
-    if (this.props.hidden) {
-      this.props.setChatHidden(false);
-      client.joinChat();
-      return;
+    if (this.props.chatContainerHidden) {
+      this.updateContainerHidden(false);
+      await this.startSession();
+      this.client.joinChat();
+    } else {
+      this.updateContainerHidden(true);
+      this.client.leaveChat();
     }
-
-    this.props.setChatHidden(true);
-    client.leaveChat();
   };
 
   render() {
-    if (!this.state.agentsAvailable) return null;
-
     return (
       <div className="Launcher">
-        <ChatContainer />
+        {!this.props.chatContainerHidden && <ChatContainer />}
         {QUIQ.CUSTOM_LAUNCH_BUTTONS.length === 0 &&
+          !inStandaloneMode() &&
+          !this.props.chatLauncherHidden &&
           <ToggleChatButton toggleChat={this.toggleChat} />}
       </div>
     );
@@ -155,9 +278,12 @@ export default compose(
   injectIntl,
   connect(
     (state: ChatState) => ({
-      hidden: state.hidden,
+      chatContainerHidden: state.chatContainerHidden,
+      chatLauncherHidden: state.chatLauncherHidden,
       popped: state.popped,
+      initializedState: state.initializedState,
+      transcript: state.transcript,
     }),
-    {setChatHidden, setChatPopped},
+    chatActions,
   ),
 )(Launcher);

--- a/app/components/ToggleChatButton.js
+++ b/app/components/ToggleChatButton.js
@@ -9,14 +9,14 @@ import './styles/ToggleChatButton.scss';
 
 export type ToggleChatButtonProps = {
   toggleChat: () => void,
-  hidden: boolean,
+  chatContainerHidden: boolean,
 };
 
 const {COLOR} = QUIQ;
 
-export const ToggleChatButton = ({toggleChat, hidden}: ToggleChatButtonProps) =>
+export const ToggleChatButton = ({toggleChat, chatContainerHidden}: ToggleChatButtonProps) =>
   <button style={{background: COLOR}} onClick={toggleChat} className="ToggleChatButton">
-    {!hidden
+    {!chatContainerHidden
       ? <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
           <path d="M23 20.168l-8.185-8.187 8.185-8.174-2.832-2.807-8.182 8.179-8.176-8.179-2.81 2.81 8.186 8.196-8.186 8.184 2.81 2.81 8.203-8.192 8.18 8.192z" />
           X
@@ -25,5 +25,5 @@ export const ToggleChatButton = ({toggleChat, hidden}: ToggleChatButtonProps) =>
   </button>;
 
 export default connect((state: ChatState) => ({
-  hidden: state.hidden,
+  chatContainerHidden: state.chatContainerHidden,
 }))(ToggleChatButton);

--- a/app/components/__tests__/ChatContainer.test.js
+++ b/app/components/__tests__/ChatContainer.test.js
@@ -4,40 +4,28 @@ jest.mock('../../ChatClient');
 jest.mock('utils/utils');
 import React from 'react';
 import {ChatContainer} from '../ChatContainer';
-import {getMockMessage} from 'utils/testHelpers';
 import {shallow} from 'enzyme';
 import type {ShallowWrapper} from 'enzyme';
 import QUIQ from 'utils/quiq';
 import type {ChatContainerProps} from '../ChatContainer';
-import {inStandaloneMode} from 'utils/utils';
 
 jest.useFakeTimers();
 
 describe('ChatContainer component', () => {
   let wrapper: ShallowWrapper;
-  let instance: any;
   let testProps: ChatContainerProps;
   let render: () => void;
 
   beforeEach(() => {
     QUIQ.WELCOME_FORM = undefined;
     testProps = {
-      hidden: false,
-      transcript: [getMockMessage(), getMockMessage(1)],
+      chatContainerHidden: false,
       welcomeFormSubmitted: true,
       initializedState: 'initialized',
-      setChatHidden: jest.fn(),
-      setChatInitialized: jest.fn(),
-      setWelcomeFormSubmitted: jest.fn(),
-      setAgentTyping: jest.fn(),
-      updateTranscript: jest.fn(),
     };
 
     render = () => {
       wrapper = shallow(<ChatContainer {...testProps} />);
-      instance = wrapper.instance();
-      instance.componentDidMount();
-      wrapper.update();
     };
   });
 
@@ -83,6 +71,14 @@ describe('ChatContainer component', () => {
     });
   });
 
+  describe('when chatContainerHidden is true', () => {
+    it('returns null', () => {
+      testProps.chatContainerHidden = true;
+      render();
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
   describe('welcome form', () => {
     describe('when welcome form has not been submitted', () => {
       it('renders welcome form', () => {
@@ -98,26 +94,6 @@ describe('ChatContainer component', () => {
       QUIQ.CUSTOM_LAUNCH_BUTTONS = ['.customButton'];
       render();
       expect(wrapper.hasClass('hasCustomLauncher')).toBe(true);
-    });
-  });
-
-  describe('standalone mode', () => {
-    it('inits on mount', () => {
-      (inStandaloneMode: any).mockReturnValue(true);
-      render();
-      expect(testProps.setChatHidden).toBeCalledWith(false);
-      expect(testProps.setChatInitialized).toBeCalledWith('loading');
-      expect(wrapper.hasClass('standaloneMode')).toBe(true);
-    });
-  });
-
-  describe('handleAgentTyping', () => {
-    it('handles agent typing', () => {
-      render();
-      instance.handleAgentTyping(true);
-      expect(testProps.setAgentTyping).toBeCalledWith(true);
-      jest.runTimersToTime(11000);
-      expect(testProps.setAgentTyping).toBeCalledWith(false);
     });
   });
 });

--- a/app/components/__tests__/HeaderMenu.test.js
+++ b/app/components/__tests__/HeaderMenu.test.js
@@ -16,7 +16,7 @@ describe('HeaderMenu component', () => {
 
   beforeEach(() => {
     testProps = {
-      setChatHidden: jest.fn(),
+      setChatContainerHidden: jest.fn(),
       setChatPopped: jest.fn(),
     };
 
@@ -36,7 +36,7 @@ describe('HeaderMenu component', () => {
     it('calls minimize', () => {
       render();
       wrapper.find('.fa-window-minimize').simulate('click');
-      expect(testProps.setChatHidden).toBeCalledWith(true);
+      expect(testProps.setChatContainerHidden).toBeCalledWith(true);
       expect(getChatClient().leaveChat).toBeCalled();
     });
   });

--- a/app/components/__tests__/Launcher.test.js
+++ b/app/components/__tests__/Launcher.test.js
@@ -1,13 +1,15 @@
 // @flow
 jest.mock('utils/utils');
+jest.mock('utils/quiq');
 jest.mock('../../ChatClient');
-import QUIQ from 'utils/quiq';
+import QUIQ, {openStandaloneMode} from 'utils/quiq';
 import React from 'react';
 import {Launcher} from '../Launcher';
 import {shallow} from 'enzyme';
-import {TestIntlObject} from 'utils/testHelpers';
+import {TestIntlObject, getMockMessage} from 'utils/testHelpers';
 import type {ShallowWrapper} from 'enzyme';
 import type {LauncherProps} from '../Launcher';
+import {inStandaloneMode, isIEorSafari} from 'utils/utils';
 import {getChatClient} from '../../ChatClient';
 
 jest.useFakeTimers();
@@ -21,60 +23,144 @@ describe('Launcher component', () => {
   const client = getChatClient();
 
   let checkForAgentsResponse;
-  let hasActiveChatResponse;
+  let hasTakenMeaningfulActionResponse;
   let isChatVisibleResponse;
 
   const updateAgentsAvailable = (available?: boolean = true) => {
     checkForAgentsResponse = Promise.resolve({available});
+    client.checkForAgents = jest.fn(() => checkForAgentsResponse);
   };
 
-  const updateHasActiveChat = (active?: boolean = true) => {
-    hasActiveChatResponse = Promise.resolve(active);
+  const updateHasTakenMeaningfulAction = (hasTakenAction?: boolean = true) => {
+    hasTakenMeaningfulActionResponse = hasTakenAction;
+    client.hasTakenMeaningfulAction = jest.fn(() => hasTakenMeaningfulActionResponse);
   };
 
   const updateIsChatVisible = (visible?: boolean = true) => {
     isChatVisibleResponse = visible;
+    client.isChatVisible = jest.fn(() => isChatVisibleResponse);
   };
 
   beforeEach(() => {
+    testProps = {
+      intl: TestIntlObject,
+      chatContainerHidden: false,
+      chatLauncherHidden: false,
+      initializedState: 'initialized',
+      transcript: [],
+      popped: false,
+
+      setChatPopped: jest.fn(),
+      setChatContainerHidden: jest.fn(),
+      setChatLauncherHidden: jest.fn(),
+      setChatInitialized: jest.fn(),
+      setWelcomeFormSubmitted: jest.fn(),
+      setAgentTyping: jest.fn(),
+      updateTranscript: jest.fn(),
+    };
+
     init = () => {
       updateAgentsAvailable();
-      updateHasActiveChat();
+      updateHasTakenMeaningfulAction();
       updateIsChatVisible();
     };
 
     render = async () => {
       client.checkForAgents.mockReturnValue(checkForAgentsResponse);
       client.isChatVisible.mockReturnValue(isChatVisibleResponse);
-      client.hasActiveChat.mockReturnValue(hasActiveChatResponse);
+      client.hasTakenMeaningfulAction.mockReturnValue(hasTakenMeaningfulActionResponse);
 
-      testProps = {
-        intl: TestIntlObject,
-        setChatHidden: jest.fn(),
-        setChatPopped: jest.fn(),
-        hidden: false,
-        popped: false,
-      };
       wrapper = shallow(<Launcher {...testProps} />);
       instance = wrapper.instance();
       instance.componentDidMount();
 
       await checkForAgentsResponse;
-      await hasActiveChatResponse;
+      await hasTakenMeaningfulActionResponse;
       wrapper.update();
     };
 
     init();
   });
 
-  describe('after a minute', () => {
-    beforeEach(async () => {
+  describe('agentTyping', () => {
+    it('stops typing after 10 seconds', async () => {
       await render();
-      jest.runTimersToTime(1000 * 60);
+      instance.handleAgentTyping(true);
+      expect(testProps.setAgentTyping).toBeCalledWith(true);
+      jest.runTimersToTime(11000);
+      expect(testProps.setAgentTyping).toBeCalledWith(false);
+    });
+  });
+
+  describe('toggleChat', () => {
+    describe('when popped', () => {
+      it('focuses standalone mode', async () => {
+        testProps.popped = true;
+        await render();
+        await instance.toggleChat();
+        expect(openStandaloneMode).toBeCalled();
+      });
     });
 
-    it('calls checkForAgents again', () => {
-      expect(client.checkForAgents.mock.calls.length).toBe(2);
+    describe('when in IE/Safari', () => {
+      it('opens standalone mode', async () => {
+        (isIEorSafari: any).mockReturnValue(() => true);
+        await render();
+        await instance.toggleChat();
+        expect(openStandaloneMode).toBeCalled();
+        (isIEorSafari: any).mockReset();
+      });
+    });
+
+    describe('when chat container is not visible', () => {
+      it('toggles chat', async () => {
+        await render();
+        wrapper.setProps({chatContainerHidden: false});
+        wrapper.update();
+        await instance.toggleChat();
+        expect(testProps.setChatContainerHidden).toBeCalledWith(true);
+        wrapper.setProps({chatContainerHidden: true});
+        wrapper.update();
+        await instance.toggleChat();
+        expect(testProps.setChatContainerHidden).toBeCalledWith(false);
+      });
+    });
+  });
+
+  describe('initial states', () => {
+    describe('standaloneMode', () => {
+      it('sets state for standalone', async () => {
+        updateIsChatVisible(false);
+        updateHasTakenMeaningfulAction(false);
+        testProps.initializedState = 'uninitialized';
+        (inStandaloneMode: any).mockReturnValue(() => true);
+        await render();
+        expect(wrapper).toMatchSnapshot();
+        (inStandaloneMode: any).mockReset();
+      });
+    });
+
+    describe('chatVisisble', () => {
+      describe('when there is a transcript', () => {
+        it('goes straight to the chat', async () => {
+          updateIsChatVisible(true);
+          updateHasTakenMeaningfulAction(false);
+          testProps.initializedState = 'uninitialized';
+          testProps.transcript = [getMockMessage()];
+          await render();
+          expect(wrapper).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('when user has taken meaningful action', () => {
+      it('starts a session', async () => {
+        updateIsChatVisible(false);
+        updateHasTakenMeaningfulAction(true);
+        testProps.initializedState = 'uninitialized';
+        await render();
+        expect(client.start).toBeCalled();
+      });
     });
   });
 
@@ -89,6 +175,7 @@ describe('Launcher component', () => {
         beforeEach(async () => {
           QUIQ.CUSTOM_LAUNCH_BUTTONS = ['.customButton1', '#customButton2'];
           await render();
+          instance.updateCustomChatButtons = jest.fn();
         });
 
         it("doesn't render the default launcher", () => {
@@ -98,12 +185,10 @@ describe('Launcher component', () => {
         describe('agentsAvailable', () => {
           describe('when agents change', () => {
             it('alters the noAgentsAvailable class', () => {
-              instance.updateCustomChatButtons = jest.fn();
-              instance.setState({agentsAvailable: false});
-              expect(instance.updateCustomChatButtons).toBeCalledWith(false);
-              instance.updateCustomChatButtons = jest.fn();
-              instance.setState({agentsAvailable: true});
+              wrapper.setProps({chatLauncherHidden: true});
               expect(instance.updateCustomChatButtons).toBeCalledWith(true);
+              wrapper.setProps({chatLauncherHidden: false});
+              expect(instance.updateCustomChatButtons).toBeCalledWith(false);
             });
           });
         });
@@ -121,6 +206,8 @@ describe('Launcher component', () => {
 
   describe('auto pop for chat', () => {
     beforeEach(async () => {
+      updateIsChatVisible(false);
+      testProps.chatContainerHidden = true;
       QUIQ.AUTO_POP_TIME = 200;
       await render();
     });
@@ -128,27 +215,42 @@ describe('Launcher component', () => {
     it("opens the chat even if the end user doesn't click on it", () => {
       jest.runTimersToTime(200);
       wrapper.update();
-      expect(testProps.setChatHidden).lastCalledWith(false);
+      expect(testProps.setChatContainerHidden).lastCalledWith(false);
     });
   });
 
-  describe('when agents are not available', () => {
-    describe('when there is not a conversation already in progress', () => {
-      it('hides the launcher', async () => {
-        updateAgentsAvailable(false);
-        updateHasActiveChat(false);
-        await render();
+  describe('after a minute', () => {
+    it('calls checkForAgents again', async () => {
+      updateHasTakenMeaningfulAction(false);
+      updateIsChatVisible(false);
+      testProps.chatContainerHidden = true;
+      await render();
+      expect(client.checkForAgents).toBeCalled();
+      jest.runTimersToTime(1000 * 60);
+      expect(client.checkForAgents).toBeCalled();
+    });
 
-        expect(wrapper).toMatchSnapshot();
+    describe('when chat container is not hidden', () => {
+      it('assumes agents available', async () => {
+        testProps.chatLauncherHidden = true;
+        updateHasTakenMeaningfulAction(false);
+        testProps.chatContainerHidden = true;
+        await render();
+        wrapper.setProps({chatContainerHidden: false});
+        jest.runTimersToTime(1000 * 60);
+        expect(testProps.setChatLauncherHidden).lastCalledWith(false);
       });
     });
 
-    describe('when there is an active conversation in progress', () => {
-      it('renders the chat', async () => {
-        updateAgentsAvailable(false);
+    describe('when client is popped into standalone mode', () => {
+      it('assumes agents available', async () => {
+        testProps.chatLauncherHidden = true;
+        updateHasTakenMeaningfulAction(false);
+        testProps.chatContainerHidden = true;
         await render();
-
-        expect(wrapper).toMatchSnapshot();
+        (inStandaloneMode: any).mockReturnValue(() => false);
+        jest.runTimersToTime(1000 * 60);
+        expect(testProps.setChatLauncherHidden).lastCalledWith(false);
       });
     });
   });

--- a/app/components/__tests__/ToggleChatButton.test.js
+++ b/app/components/__tests__/ToggleChatButton.test.js
@@ -13,7 +13,7 @@ describe('ToggleChatButton component', () => {
   beforeEach(() => {
     testProps = {
       toggleChat: jest.fn(),
-      hidden: true,
+      chatContainerHidden: true,
     };
     render = () => {
       wrapper = shallow(<ToggleChatButton {...testProps} />);
@@ -29,7 +29,7 @@ describe('ToggleChatButton component', () => {
 
   describe('open', () => {
     it('switches svgs', () => {
-      testProps.hidden = false;
+      testProps.chatContainerHidden = false;
       render();
 
       expect(wrapper).toMatchSnapshot();

--- a/app/components/__tests__/__snapshots__/ChatContainer.test.js.snap
+++ b/app/components/__tests__/__snapshots__/ChatContainer.test.js.snap
@@ -167,3 +167,5 @@ exports[`ChatContainer component initializedState when uninitialized renders pro
   </div>
 </div>
 `;
+
+exports[`ChatContainer component when chatContainerHidden is true returns null 1`] = `null`;

--- a/app/components/__tests__/__snapshots__/Launcher.test.js.snap
+++ b/app/components/__tests__/__snapshots__/Launcher.test.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Launcher component initial states chatVisisble when there is a transcript goes straight to the chat 1`] = `
+<div
+  className="Launcher"
+>
+  <Connect(ChatContainer) />
+  <Connect(ToggleChatButton)
+    toggleChat={[Function]}
+  />
+</div>
+`;
+
+exports[`Launcher component initial states standaloneMode sets state for standalone 1`] = `
+<div
+  className="Launcher"
+>
+  <Connect(ChatContainer) />
+</div>
+`;
+
 exports[`Launcher component when agents are available renders 1`] = `
 <div
   className="Launcher"
@@ -10,16 +29,3 @@ exports[`Launcher component when agents are available renders 1`] = `
   />
 </div>
 `;
-
-exports[`Launcher component when agents are not available when there is an active conversation in progress renders the chat 1`] = `
-<div
-  className="Launcher"
->
-  <Connect(ChatContainer) />
-  <Connect(ToggleChatButton)
-    toggleChat={[Function]}
-  />
-</div>
-`;
-
-exports[`Launcher component when agents are not available when there is not a conversation already in progress hides the launcher 1`] = `null`;

--- a/app/reducers/__tests__/chat.test.js
+++ b/app/reducers/__tests__/chat.test.js
@@ -2,24 +2,39 @@
 jest.mock('utils/utils');
 import chat from '../chat';
 import {getMockMessage} from 'utils/testHelpers';
-import {isIEorSafari} from 'utils/utils';
+import {isIEorSafari, inStandaloneMode} from 'utils/utils';
 
 describe('chat reducers', () => {
   afterEach(() => {
     (isIEorSafari: any).mockReset();
+    (inStandaloneMode: any).mockReset();
   });
 
-  describe('CHAT_HIDDEN', () => {
+  describe('CHAT_CONTAINER_HIDDEN', () => {
     it('updates state with the new value', () => {
-      expect(chat.getState().hidden).toBe(true);
-      chat.dispatch({type: 'CHAT_HIDDEN', hidden: false});
-      expect(chat.getState().hidden).toBe(false);
+      expect(chat.getState().chatContainerHidden).toBe(true);
+      chat.dispatch({type: 'CHAT_CONTAINER_HIDDEN', chatContainerHidden: false});
+      expect(chat.getState().chatContainerHidden).toBe(false);
     });
 
-    it('always sets hidden to true in IE/Safari', () => {
+    it('always sets chatContainerHidden to true in IE/Safari', () => {
       (isIEorSafari: any).mockReturnValue(true);
-      chat.dispatch({type: 'CHAT_HIDDEN', hidden: false});
-      expect(chat.getState().hidden).toBe(true);
+      chat.dispatch({type: 'CHAT_CONTAINER_HIDDEN', chatContainerHidden: false});
+      expect(chat.getState().chatContainerHidden).toBe(true);
+    });
+  });
+
+  describe('CHAT_LAUNCHER_HIDDEN', () => {
+    it('updates state with the new value', () => {
+      expect(chat.getState().chatLauncherHidden).toBe(true);
+      chat.dispatch({type: 'CHAT_LAUNCHER_HIDDEN', chatLauncherHidden: false});
+      expect(chat.getState().chatLauncherHidden).toBe(false);
+    });
+
+    it('always sets chatLauncherHidden to true in standalone mode', () => {
+      (inStandaloneMode: any).mockReturnValue(true);
+      chat.dispatch({type: 'CHAT_LAUNCHER_HIDDEN', chatLauncherHidden: false});
+      expect(chat.getState().chatLauncherHidden).toBe(true);
     });
   });
 
@@ -35,18 +50,18 @@ describe('chat reducers', () => {
     it('updates state with the new value', () => {
       chat.dispatch({type: 'CHAT_POPPED', popped: true});
       expect(chat.getState().popped).toBe(true);
-      expect(chat.getState().hidden).toBe(true);
+      expect(chat.getState().chatContainerHidden).toBe(true);
 
       chat.dispatch({type: 'CHAT_POPPED', popped: false});
       expect(chat.getState().popped).toBe(false);
-      expect(chat.getState().hidden).toBe(false);
+      expect(chat.getState().chatContainerHidden).toBe(false);
     });
 
-    it('always sets hidden to true in IE/Safari', () => {
+    it('always sets chatContainerHidden to true in IE/Safari', () => {
       (isIEorSafari: any).mockReturnValue(true);
       chat.dispatch({type: 'CHAT_POPPED', popped: false});
       expect(chat.getState().popped).toBe(false);
-      expect(chat.getState().hidden).toBe(true);
+      expect(chat.getState().chatContainerHidden).toBe(true);
     });
   });
 

--- a/app/reducers/chat.js
+++ b/app/reducers/chat.js
@@ -6,7 +6,8 @@ import QUIQ from 'utils/quiq';
 import type {ChatState, Action, ChatInitializedStateType, Message} from 'types';
 
 type ChatAction = {
-  hidden?: boolean,
+  chatContainerHidden?: boolean,
+  chatLauncherHidden?: boolean,
   initializedState?: ChatInitializedStateType,
   popped?: boolean,
   transcript?: Array<Message>,
@@ -19,13 +20,19 @@ const launchingFromIEorSafari = () => isIEorSafari() && !inStandaloneMode();
 
 const reducer = (state: ChatState, action: Action & ChatAction) => {
   switch (action.type) {
-    case 'CHAT_HIDDEN':
-      return Object.assign({}, state, {hidden: launchingFromIEorSafari() ? true : action.hidden});
+    case 'CHAT_CONTAINER_HIDDEN':
+      return Object.assign({}, state, {
+        chatContainerHidden: launchingFromIEorSafari() ? true : action.chatContainerHidden,
+      });
+    case 'CHAT_LAUNCHER_HIDDEN':
+      return Object.assign({}, state, {
+        chatLauncherHidden: inStandaloneMode() ? true : action.chatLauncherHidden,
+      });
     case 'CHAT_INITIALIZED_STATE':
       return Object.assign({}, state, {initializedState: action.initializedState});
     case 'CHAT_POPPED': {
       return Object.assign({}, state, {
-        hidden: launchingFromIEorSafari() ? true : action.popped,
+        chatContainerHidden: launchingFromIEorSafari() ? true : action.popped,
         popped: action.popped,
       });
     }
@@ -40,11 +47,16 @@ const reducer = (state: ChatState, action: Action & ChatAction) => {
   }
 };
 
-export default createStore(reducer, {
-  hidden: true,
-  initializedState: ChatInitializedState.UNINITIALIZED,
-  popped: false,
-  transcript: [],
-  agentTyping: false,
-  welcomeFormSubmitted: !QUIQ.WELCOME_FORM,
-});
+export default createStore(
+  reducer,
+  {
+    chatContainerHidden: true,
+    chatLauncherHidden: true,
+    initializedState: ChatInitializedState.UNINITIALIZED,
+    popped: false,
+    transcript: [],
+    agentTyping: false,
+    welcomeFormSubmitted: !QUIQ.WELCOME_FORM,
+  },
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+);

--- a/app/types.js
+++ b/app/types.js
@@ -13,7 +13,8 @@ export type WelcomeForm = {
 };
 
 export type ChatState = {
-  hidden: boolean,
+  chatContainerHidden: boolean,
+  chatLauncherHidden: boolean,
   initializedState: ChatInitializedStateType,
   popped: boolean,
   transcript: Array<Message>,
@@ -23,7 +24,8 @@ export type ChatState = {
 
 export type Action = {
   type:
-    | 'CHAT_HIDDEN'
+    | 'CHAT_CONTAINER_HIDDEN'
+    | 'CHAT_LAUNCHER_HIDDEN'
     | 'CHAT_INITIALIZED_STATE'
     | 'CHAT_POPPED'
     | 'UPDATE_TRANSCRIPT'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Webchat",
   "description": "Quiq Webchat",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "author": "Quiq",
   "license": "ISC",
   "private": true,
@@ -143,7 +143,7 @@
     "intl": "1.2.5",
     "lodash": "4.17.4",
     "qs": "6.4.0",
-    "quiq-chat": "1.6.1",
+    "quiq-chat": "1.7.1",
     "react": "15.6.0",
     "react-addons-update": "15.6.0",
     "react-dom": "15.6.0",


### PR DESCRIPTION
Moved all initialization logic the the Launcher component since it is the only entry point we can determine all of the info we need without making additional network requests. 

Consumed new quiq-chat changes

Make standalone mode use Launcher, and just hide the launcher output.

Determine transcript length on client rather than in quiq-chat for deciding when to show launcher.