### PR TITLE
window.name

### DIFF
--- a/app/utils/__tests__/utils.test.js
+++ b/app/utils/__tests__/utils.test.js
@@ -1,30 +1,6 @@
 import * as Utils from 'utils/utils';
-import {mockLocation} from 'utils/testHelpers';
 
 describe('Utils', () => {
-  describe('getCleansedLocation', () => {
-    beforeEach(mockLocation);
-
-    it('Removes the QUIQ Object', () => {
-      window.location.href = 'testUrl.com';
-      expect(Utils.getCleansedLocation()).toBe(window.location.href);
-
-      window.location.gref = 'testUrl.com/standalone/hey';
-      expect(Utils.getCleansedLocation()).toBe(window.location.href);
-
-      const baseUrl = 'testUrl.com/standalone/hey?test=hey';
-
-      window.location.href = baseUrl;
-      expect(Utils.getCleansedLocation()).toBe(baseUrl);
-
-      window.location.href = `${baseUrl}&QUIQ=test`;
-      expect(Utils.getCleansedLocation()).toBe(baseUrl);
-
-      window.location.href = `${baseUrl}&QUIQ=test&foo=bar`;
-      expect(Utils.getCleansedLocation()).toBe(`${baseUrl}&foo=bar`);
-    });
-  });
-
   describe('camelize', () => {
     it('converts Sentence Case to camelCase', () => {
       expect(Utils.camelize('Sentence Case')).toBe('sentenceCase');

--- a/app/utils/quiq.js
+++ b/app/utils/quiq.js
@@ -6,13 +6,10 @@ import {
   getWebchatUrlFromScriptTag,
   displayError,
   inStandaloneMode,
-  isIE9,
   isIEorSafari,
   camelize,
 } from './utils';
-import {compressToEncodedURIComponent, decompressFromEncodedURIComponent} from 'lz-string';
 import {SupportedWebchatUrls} from 'appConstants';
-import qs from 'qs';
 import type {QuiqObject, WelcomeForm} from 'types';
 
 const reservedKeyNames = ['Referrer'];
@@ -57,12 +54,9 @@ const processWelcomeForm = (form: WelcomeForm): void => {
 
 const assignQuiqObjInStandaloneMode = () => {
   if (!inStandaloneMode()) return;
-
-  const queryString = qs.parse(window.location.href.split('?')[1]);
-  if (!queryString || !queryString.QUIQ) return displayError(messages.standaloneFatalError);
-
   try {
-    window.QUIQ = JSON.parse(decompressFromEncodedURIComponent(queryString.QUIQ));
+    window.QUIQ = JSON.parse(window.name.split('quiq-standalone-webchat')[1]);
+    window.name = 'quiq-standalone-webchat';
   } catch (e) {
     return displayError(messages.errorParsingStandaloneObject);
   }
@@ -220,12 +214,8 @@ export const openStandaloneMode = (callbacks: {
   const left = screen.width / 2 - width / 2;
   const top = screen.height / 2 - height / 2;
   window.QUIQ_STANDALONE_WINDOW_HANDLE = open(
-    `${__DEV__
-      ? 'http://localhost:3000'
-      : QUIQ.HOST}/app/webchat/standalone?QUIQ=${compressToEncodedURIComponent(
-      JSON.stringify(QUIQ),
-    )}`,
-    isIE9() ? '_blank' : 'quiq-standalone-webchat',
+    `${__DEV__ ? 'http://0.tcp.ngrok.io:17216' : QUIQ.HOST}/app/webchat/standalone`,
+    `quiq-standalone-webchat${JSON.stringify(QUIQ)}`,
     `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, copyhistory=no, resizable=no, width=${width}, height=${height}, top=${top}, left=${left}`,
   );
   window.QUIQ_STANDALONE_WINDOW_HANDLE.focus();

--- a/app/utils/quiq.js
+++ b/app/utils/quiq.js
@@ -214,7 +214,7 @@ export const openStandaloneMode = (callbacks: {
   const left = screen.width / 2 - width / 2;
   const top = screen.height / 2 - height / 2;
   window.QUIQ_STANDALONE_WINDOW_HANDLE = open(
-    `${__DEV__ ? 'http://0.tcp.ngrok.io:17216' : QUIQ.HOST}/app/webchat/standalone`,
+    `${__DEV__ ? 'http://localhsot:3000' : QUIQ.HOST}/app/webchat/standalone`,
     `quiq-standalone-webchat${JSON.stringify(QUIQ)}`,
     `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, copyhistory=no, resizable=no, width=${width}, height=${height}, top=${top}, left=${left}`,
   );

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -6,7 +6,6 @@ import messages from 'messages';
 import {getDisplayString} from 'utils/i18n';
 import {SupportedWebchatUrls} from 'appConstants';
 import {UAParser} from 'ua-parser-js';
-import qs from 'qs';
 import type {BrowserNames, DeviceTypes, OSNames, IntlMessage} from 'types';
 
 const parser = new UAParser();
@@ -55,20 +54,6 @@ export const displayError = (error: IntlMessage | string, values: {[string]: str
 };
 
 export const inStandaloneMode = () => window.location.href.includes('standalone');
-
-export const getCleansedLocation = () => {
-  if (!inStandaloneMode()) return window.location.href;
-
-  const host = window.location.href.split('?')[0];
-  const queryString = qs.parse(window.location.href.split('?')[1]);
-  if (!queryString || !queryString.QUIQ) return window.location.href;
-
-  delete queryString.QUIQ;
-
-  if (Object.keys(queryString).length === 0) return host;
-
-  return `${host}?${qs.stringify(queryString)}`;
-};
 
 export const getWebchatUrlFromScriptTag = () => {
   // eslint-disable-line no-unused-vars

--- a/package.json
+++ b/package.json
@@ -134,8 +134,6 @@
     "classnames": "2.2.5",
     "intl": "1.2.5",
     "lodash": "4.17.4",
-    "lz-string": "1.4.4",
-    "qs": "6.4.0",
     "quiq-chat": "1.8.1",
     "react": "15.6.0",
     "react-addons-update": "15.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Webchat",
   "description": "Quiq Webchat",
-  "version": "1.0.118",
+  "version": "1.0.119",
   "author": "Quiq",
   "license": "ISC",
   "private": true,


### PR DESCRIPTION
So the compression originally used in this branch didn't compress enough to alleviate the problem.  This problem started occurring from the string override work.  I found a different method for passing data through window.open, using the window name param.  I tested a string of 50,000 characters across Chrome, Firefox, Safari, and IE 11/10 and it worked in all.  This should be plenty to get us through the woods for the foreseeable future (we can add compression on top if this if needed).