### PR TITLE
Remove Safari logic that is no longer needed

### DIFF
--- a/app/components/HeaderMenu.js
+++ b/app/components/HeaderMenu.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {inStandaloneMode, isIEorSafari} from 'utils/utils';
+import {inStandaloneMode} from 'utils/utils';
 import QUIQ, {openStandaloneMode, getStyle, getMessage} from 'utils/quiq';
 import {messageTypes, ChatInitializedState} from 'appConstants';
 import {setChatContainerHidden, setChatPopped} from 'actions/chatActions';
@@ -31,9 +31,6 @@ export const HeaderMenu = (props: HeaderMenuProps) => {
       },
       onDock: () => {
         props.setChatPopped(false);
-        if (isIEorSafari()) {
-          getChatClient().leaveChat();
-        }
       },
     });
   };
@@ -45,14 +42,12 @@ export const HeaderMenu = (props: HeaderMenuProps) => {
   return (
     <div className="HeaderMenu" style={headerStyle}>
       <div className="buttons">
-        {!isIEorSafari() &&
-          <i
-            className={`fa fa-window-minimize icon`}
-            title={getMessage(messageTypes.minimizeWindowTooltip)}
-            onClick={inStandaloneMode() ? window.close : minimize}
-          />}
-        {!isIEorSafari() &&
-          props.initializedState !== ChatInitializedState.BURNED &&
+        <i
+          className={`fa fa-window-minimize icon`}
+          title={getMessage(messageTypes.minimizeWindowTooltip)}
+          onClick={inStandaloneMode() ? window.close : minimize}
+        />
+        {props.initializedState !== ChatInitializedState.BURNED &&
           <i
             className={`fa fa-${inStandaloneMode() ? 'window-restore' : 'window-maximize'} icon`}
             title={getMessage(

--- a/app/components/Launcher.js
+++ b/app/components/Launcher.js
@@ -9,7 +9,7 @@ import './styles/Launcher.scss';
 import * as chatActions from 'actions/chatActions';
 import {getChatClient} from '../ChatClient';
 import messages from 'messages';
-import {displayError, isIEorSafari, isMobile, inStandaloneMode} from 'utils/utils';
+import {displayError, isMobile, inStandaloneMode} from 'utils/utils';
 import {noAgentsAvailableClass, mobileClass, ChatInitializedState} from 'appConstants';
 import {connect} from 'react-redux';
 import {compose} from 'redux';
@@ -22,17 +22,17 @@ type LauncherState = {
 
 export type LauncherProps = {
   intl: IntlObject,
+  popped: boolean,
   chatContainerHidden: boolean,
   chatLauncherHidden: boolean,
   initializedState: ChatInitializedStateType,
   transcript: Array<Message>,
   welcomeFormRegistered: boolean,
-  popped: boolean,
 
-  setChatPopped: (popped: boolean) => void,
   setChatContainerHidden: (chatContainerHidden: boolean) => void,
   setChatLauncherHidden: (chatLauncherHidden: boolean) => void,
   setChatInitialized: (initialized: ChatInitializedStateType) => void,
+  setChatPopped: (popped: boolean) => void,
   setWelcomeFormRegistered: () => void,
   setAgentTyping: (typing: boolean) => void,
   updateTranscript: (transcript: Array<Message>) => void,
@@ -209,7 +209,7 @@ export class Launcher extends Component {
   };
 
   handleAutoPop = () => {
-    if (!isIEorSafari() && !isMobile() && typeof QUIQ.AUTO_POP_TIME === 'number') {
+    if (!isMobile() && typeof QUIQ.AUTO_POP_TIME === 'number') {
       this.autoPopTimeout = setTimeout(() => {
         if (this.props.chatLauncherHidden) return;
 
@@ -257,20 +257,16 @@ export class Launcher extends Component {
       return;
     }
 
-    if (this.props.popped || isIEorSafari()) {
+    if (this.props.popped) {
       return openStandaloneMode({
         onPop: () => {
           this.props.setChatPopped(true);
-          getChatClient().joinChat();
         },
         onFocus: () => {
           this.props.setChatPopped(true);
         },
         onDock: () => {
           this.props.setChatPopped(false);
-          if (isIEorSafari()) {
-            getChatClient().leaveChat();
-          }
         },
       });
     }

--- a/app/components/__tests__/Launcher.test.js
+++ b/app/components/__tests__/Launcher.test.js
@@ -9,7 +9,7 @@ import {shallow} from 'enzyme';
 import {TestIntlObject, getMockMessage} from 'utils/testHelpers';
 import type {ShallowWrapper} from 'enzyme';
 import type {LauncherProps} from '../Launcher';
-import {inStandaloneMode, isIEorSafari} from 'utils/utils';
+import {inStandaloneMode} from 'utils/utils';
 import {getChatClient} from '../../ChatClient';
 
 jest.useFakeTimers();
@@ -109,17 +109,6 @@ describe('Launcher component', () => {
         await render();
         await instance.toggleChat();
         expect(openStandaloneMode).toBeCalled();
-      });
-    });
-
-    describe('when in IE/Safari', () => {
-      it('opens standalone mode', async () => {
-        testProps.initializedState = 'uninitialized';
-        (isIEorSafari: any).mockReturnValue(() => true);
-        await render();
-        await instance.toggleChat();
-        expect(openStandaloneMode).toBeCalled();
-        (isIEorSafari: any).mockReset();
       });
     });
 

--- a/app/reducers/__tests__/chat.test.js
+++ b/app/reducers/__tests__/chat.test.js
@@ -2,11 +2,10 @@
 jest.mock('utils/utils');
 import chat from '../chat';
 import {getMockMessage} from 'utils/testHelpers';
-import {isIEorSafari, inStandaloneMode} from 'utils/utils';
+import {inStandaloneMode} from 'utils/utils';
 
 describe('chat reducers', () => {
   afterEach(() => {
-    (isIEorSafari: any).mockReset();
     (inStandaloneMode: any).mockReset();
   });
 
@@ -15,12 +14,6 @@ describe('chat reducers', () => {
       expect(chat.getState().chatContainerHidden).toBe(true);
       chat.dispatch({type: 'CHAT_CONTAINER_HIDDEN', chatContainerHidden: false});
       expect(chat.getState().chatContainerHidden).toBe(false);
-    });
-
-    it('always sets chatContainerHidden to true in IE/Safari', () => {
-      (isIEorSafari: any).mockReturnValue(true);
-      chat.dispatch({type: 'CHAT_CONTAINER_HIDDEN', chatContainerHidden: false});
-      expect(chat.getState().chatContainerHidden).toBe(true);
     });
   });
 
@@ -63,13 +56,6 @@ describe('chat reducers', () => {
       chat.dispatch({type: 'CHAT_POPPED', popped: false});
       expect(chat.getState().popped).toBe(false);
       expect(chat.getState().chatContainerHidden).toBe(false);
-    });
-
-    it('always sets chatContainerHidden to true in IE/Safari', () => {
-      (isIEorSafari: any).mockReturnValue(true);
-      chat.dispatch({type: 'CHAT_POPPED', popped: false});
-      expect(chat.getState().popped).toBe(false);
-      expect(chat.getState().chatContainerHidden).toBe(true);
     });
   });
 

--- a/app/reducers/chat.js
+++ b/app/reducers/chat.js
@@ -1,5 +1,5 @@
 // @flow
-import {isIEorSafari, inStandaloneMode} from 'utils/utils';
+import {inStandaloneMode} from 'utils/utils';
 import {createStore} from 'redux';
 import {ChatInitializedState} from 'appConstants';
 import QUIQ from 'utils/quiq';
@@ -13,9 +13,6 @@ type ChatAction = {
   transcript?: Array<Message>,
   agentTyping?: boolean,
 };
-
-// When docking IE/Safari, we don't want to display the standard chat.
-const launchingFromIEorSafari = () => isIEorSafari() && !inStandaloneMode();
 
 const initialState = {
   chatContainerHidden: true,
@@ -31,7 +28,7 @@ const reducer = (state: ChatState, action: Action & ChatAction) => {
   switch (action.type) {
     case 'CHAT_CONTAINER_HIDDEN':
       return Object.assign({}, state, {
-        chatContainerHidden: launchingFromIEorSafari() ? true : action.chatContainerHidden,
+        chatContainerHidden: inStandaloneMode() ? false : action.chatContainerHidden,
       });
     case 'CHAT_LAUNCHER_HIDDEN':
       return Object.assign({}, state, {
@@ -45,10 +42,9 @@ const reducer = (state: ChatState, action: Action & ChatAction) => {
 
       return Object.assign({}, state, {initializedState: action.initializedState});
     }
-
     case 'CHAT_POPPED': {
       return Object.assign({}, state, {
-        chatContainerHidden: launchingFromIEorSafari() ? true : action.popped,
+        chatContainerHidden: inStandaloneMode() ? false : action.popped,
         popped: action.popped,
       });
     }

--- a/app/utils/__mocks__/utils.js
+++ b/app/utils/__mocks__/utils.js
@@ -33,6 +33,5 @@ export const nonCompatibleBrowser = () => false;
 export const supportsFlexbox = () => true;
 export const supportsSVG = () => true;
 export const displayError = (error: string) => error;
-export const isIEorSafari = jest.fn(() => false);
 export const inStandaloneMode = jest.fn(() => false);
 export const isMobile = jest.fn(() => false);

--- a/app/utils/quiq.js
+++ b/app/utils/quiq.js
@@ -2,13 +2,7 @@
 declare var __DEV__: string;
 import messages from 'messages';
 import {getDisplayString} from 'utils/i18n';
-import {
-  getWebchatUrlFromScriptTag,
-  displayError,
-  inStandaloneMode,
-  isIEorSafari,
-  camelize,
-} from './utils';
+import {getWebchatUrlFromScriptTag, displayError, inStandaloneMode, camelize} from './utils';
 import {SupportedWebchatUrls} from 'appConstants';
 import type {QuiqObject, WelcomeForm} from 'types';
 
@@ -63,10 +57,6 @@ const assignQuiqObjInStandaloneMode = () => {
 };
 
 const getQuiqObject = (): QuiqObject => {
-  if (!navigator.cookieEnabled) {
-    return displayError(messages.cookiesMustBeEnabledError);
-  }
-
   assignQuiqObjInStandaloneMode();
 
   const primaryColor =
@@ -142,8 +132,6 @@ const getQuiqObject = (): QuiqObject => {
   // Ensure host is defined for standalone mode,
   // since we won't be able to get it from a script tag.
   window.QUIQ.HOST = QUIQ.HOST;
-  // Don't AutoPop IE/Safari since they are always in standalone mode.
-  window.QUIQ.AUTO_POP_TIME = isIEorSafari() ? undefined : window.QUIQ.AUTO_POP_TIME;
   window.QUIQ.CUSTOM_LAUNCH_BUTTONS = inStandaloneMode()
     ? []
     : window.QUIQ.CUSTOM_LAUNCH_BUTTONS || [];

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -33,9 +33,6 @@ export const compatibilityMode = () => {
 
 export const isIE9 = () => getBrowserName() === 'IE' && getMajor() <= 9;
 export const isIE10 = () => getBrowserName() === 'IE' && getMajor() === 10;
-
-export const isIEorSafari = () => getBrowserName() === 'IE' || getBrowserName() === 'Safari';
-
 export const isMobile = () => getDeviceType() === 'mobile';
 
 export const nonCompatibleBrowser = () => getBrowserName() === 'IE' && getMajor() < 9;

--- a/index.html
+++ b/index.html
@@ -132,13 +132,13 @@ window.QUIQ = {
         id: 'lastName',
         required: false,
       },
-      {
-        type: 'textarea',
-        label: 'Life Story',
-        id: 'story',
-        required: false,
-        rows: 2,
-      },
+      // {
+      //   type: 'textarea',
+      //   label: 'Life Story',
+      //   id: 'story',
+      //   required: false,
+      //   rows: 2,
+      // },
       {
         type: 'number',
         label: 'Number Field',
@@ -167,7 +167,8 @@ window.onload = function() {
   setInterval(function() {
     if (
       !document.querySelector('.ToggleChatButton') &&
-      (!window.QUIQ.CUSTOM_LAUNCH_BUTTONS ||
+      (!window.QUIQ ||
+        !window.QUIQ.CUSTOM_LAUNCH_BUTTONS ||
         !window.QUIQ.CUSTOM_LAUNCH_BUTTONS.length ||
         document.querySelector('button').classList.contains('noAgentsAvailable'))
     ) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Webchat",
   "description": "Quiq Webchat",
-  "version": "1.0.138",
+  "version": "1.0.139",
   "author": "Quiq",
   "license": "ISC",
   "private": true,
@@ -134,7 +134,7 @@
     "classnames": "2.2.5",
     "intl": "1.2.5",
     "lodash": "4.17.4",
-    "quiq-chat": "1.8.4",
+    "quiq-chat": "1.9.0",
     "react": "15.6.0",
     "react-addons-update": "15.6.0",
     "react-dom": "15.6.0",
@@ -142,7 +142,7 @@
     "react-linkify": "0.2.1",
     "react-redux": "5.0.5",
     "react-router-dom": "4.1.1",
-    "react-textarea-autosize": "5.0.6",
+    "react-textarea-autosize": "5.1.0",
     "redux": "3.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,7 +47,7 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.1:
+acorn@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
@@ -1450,8 +1450,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000525, caniuse-db@^1.0.30000527, caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000639:
-  version "1.0.30000709"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000709.tgz#0b600072b7cdbbf6336a8758b71b9ad03268ede2"
+  version "1.0.30000712"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000712.tgz#89748396f9d7419d5fa27df3b48872dadbf8318a"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1481,8 +1481,8 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -1789,8 +1789,8 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2276,8 +2276,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.7:
-  version "1.3.16"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz#d0e026735754770901ae301a21664cba45d92f7d"
+  version "1.3.17"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz#41c13457cc7166c5c15e767ae61d86a8cacdee5d"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -2422,13 +2422,14 @@ error-stack-parser@^1.3.6:
     stackframe "^0.3.1"
 
 es-abstract@^1.6.1, es-abstract@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.0"
+    has "^1.0.1"
     is-callable "^1.1.3"
-    is-regex "^1.0.3"
+    is-regex "^1.0.4"
 
 es-to-primitive@^1.1.1:
   version "1.1.1"
@@ -2630,10 +2631,10 @@ eslint@3.19.0:
     user-home "^2.0.0"
 
 espree@^3.4.0:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
   dependencies:
-    acorn "^5.0.1"
+    acorn "^5.1.1"
     acorn-jsx "^3.0.0"
 
 esprima-fb@^15001.1.0-dev-harmony-fb:
@@ -3346,14 +3347,7 @@ http-errors@~1.5.0, http-errors@~1.5.1:
     setprototypeof "1.0.2"
     statuses ">= 1.3.1 < 2"
 
-http-proxy@^1.8.1:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
-  dependencies:
-    eventemitter3 "1.x.x"
-    requires-port "1.x.x"
-
-http-proxy@~1.11.1:
+http-proxy@^1.8.1, http-proxy@~1.11.1:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.11.3.tgz#1915dc888751e2a6bf3c2abfcb1808fa86c72353"
   dependencies:
@@ -3674,7 +3668,7 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-regex@^1.0.3:
+is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -4770,11 +4764,11 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.1.0, minimist@^1.1.0:
+minimist@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.0.tgz#cdf225e8898f840a258ded44fc91776770afdc93"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5802,9 +5796,9 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
-quiq-chat@1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/quiq-chat/-/quiq-chat-1.8.4.tgz#7f7ef5355456d78159471e5390ea3cb11d7a2a1f"
+quiq-chat@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/quiq-chat/-/quiq-chat-1.9.0.tgz#fb3799973318cc55ea7f71c47cc5c43d7243f234"
   dependencies:
     atmosphere.js "https://github.com/Quiq/atmosphere-js/tarball/cf35c913143cf2c391b6bcb694ae8a47794a1b88"
     isomorphic-fetch "2.2.1"
@@ -5944,11 +5938,11 @@ react-test-renderer@^15.5.4:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-textarea-autosize@5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.0.6.tgz#a3742e0a319484021b4dbfa1519df287768f2133"
+react-textarea-autosize@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.1.0.tgz#ffbf8164fce217c79443c1c17dedf730592df224"
   dependencies:
-    prop-types "^15.5.8"
+    prop-types "^15.5.10"
 
 react@15.6.0:
   version "15.6.0"
@@ -6210,7 +6204,7 @@ requires-port@0.x.x:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-0.0.1.tgz#4b4414411d9df7c855995dd899a8c78a2951c16d"
 
-requires-port@1.0.x, requires-port@1.x.x:
+requires-port@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 


### PR DESCRIPTION
Since we are no longer using http-only cross domain cookies, we don't need all the hacky Safari/IE logic.  Removed it.  Also let quiq-chat handle the no-cookies case since it is the one using them.